### PR TITLE
v2.0.6

### DIFF
--- a/sapphire/__parser__.py
+++ b/sapphire/__parser__.py
@@ -151,6 +151,10 @@ class Parser:
                     self.asm('psh', 0)
                 elif isinstance(c, int):
                     self.asm('psh', c)
+                elif isinstance(c, tuple):
+                    for x in c:
+                        self.asm('psh', x)
+                    build_array(len(c))
                 elif isinstance(c, str):
                     for x in c:
                         self.asm('psh', ord(x))


### PR DESCRIPTION
- New array syntax:
```python
x = [1, 2, 3]  # old, still works
x = 1, 2, 3    # new
```